### PR TITLE
Update first setup procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you wish to do RL using GPU openCL on large data, then the 'block' version is
 
 Run:
 
-`python setup.py`
+`python setup.py develop`
 
 or download and place in appropriate folder ready to be used. Make sure that it is reachable by python.
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ Copyright (C) 2021 Rosalind Franklin Institute
 
 from setuptools import setup, find_packages
 
-import RedLionfishDeconv
+# import RedLionfishDeconv
 
 
 setup(


### PR DESCRIPTION
- Import statement in setup.py requires numpy before setup has requested it
- Readme docs say that simply running setup.py without an argument is enough to install, but setuptools requires an argument such as develop