### PR TITLE
Add napari to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     license='Apache License, Version 2.0',
     zip_safe=False,
     install_requires=[
+        'napari',
         'numpy',
         'scipy'
     ],


### PR DESCRIPTION
Hi team,

My name is Draga and I am a CZI contractor working on napari.

As part of our work on the [new napari plugin engine](https://napari.org/plugins/stable/npe2_getting_started.html), we’ve been running some automated tests to see whether plugins will be easily converted to the new plugin engine. While running these tests, we noticed that your plugin fails to be imported after installation in a fresh environment due to a missing requirement. You can see details in [this github action run](https://github.com/napari/npe2/runs/4476899936?check_suite_focus=true).

This PR therefore adds `napari` to your install requirements so that users can install your plugin more confidently. 

Note that this may not be a complete list - to check whether your plugin can be easily installed on other machines, we recommend using GitHub workflows to test your plugin in a fresh environment - [the napari plugin cookiecutter](https://github.com/napari/cookiecutter-napari-plugin/blob/main/%7B%7Bcookiecutter.plugin_name%7D%7D/.github/workflows/test_and_deploy.yml) provides an example of such a workflow.

If you believe this PR has been opened in error, please feel free to close it and let us know where we went wrong!
